### PR TITLE
Blacklist Jupyter 5.0.

### DIFF
--- a/imatlab/_kernel.py
+++ b/imatlab/_kernel.py
@@ -236,9 +236,19 @@ class MatlabKernel(Kernel):
                 self._call("cd", cwd)
             for path in map(Path(tmpdir).joinpath, exported):
                 if path.suffix.lower() == ".html":
-                    self._plotly_init_notebook_mode()
-                    self._send_display_data(
-                        {"text/html": path.read_text()}, {})
+                    # https://github.com/jupyter/notebook/issues/2287
+                    # Delay import, as this is not a dependency otherwise.
+                    import notebook
+                    if notebook.__version__ == "5.0.0":
+                        self._send_stream(
+                            "stderr",
+                            "Plotly output is not supported with "
+                            "notebook==5.0.0.  Please update to a newer "
+                            "version.")
+                    else:
+                        self._plotly_init_notebook_mode()
+                        self._send_display_data(
+                            {"text/html": path.read_text()}, {})
                 elif path.suffix.lower() == ".png":
                     self._send_display_data(
                         ipykernel.jsonutil.encode_images(


### PR DESCRIPTION
... due to issues with IOPub rate limiting (yes, there are ways around
this but `pip install 'notebook!=5.0'` is simpler).

attn @imatlab-helper 

Planning to merge this myself **after jupyter 5.1 comes out**.  I don't want to document workarounds for 5.0 (https://github.com/imatlab/imatlab/issues/2#issuecomment-294107129, https://github.com/imatlab/imatlab/issues/24#issuecomment-318167728).

Thoughts?