### PR TITLE
kernel.py: execute startup.m when exists at start

### DIFF
--- a/lib/imatlab/_kernel.py
+++ b/lib/imatlab/_kernel.py
@@ -130,6 +130,12 @@ class MatlabKernel(Kernel):
             "nbconvert_exporter": "imatlab._exporter.MatlabExporter",
         }
 
+    @property
+    def banner(self):
+      msg = 'Matlab kernel running'
+      self.do_execute("try; startup; end", False, store_history=False)
+      return msg
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._silent = False


### PR DESCRIPTION
I just added a 'banner' method as proposed by Jupyter kernel specs in order to attempt execution of 'startup' at start. This is for instance to set-up an environment (proxy, local libraries and scripts, etc).