### PR TITLE
fix CJK character cannot display CORRECTLY

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 
 ```bash
-pip install git+https://github.com/dennischancs/imatlab  # from Github
+pip install git+https://github.com/dennischancs/imatlab/tree/dennischancs-patch-1  # from Github
 python -mimatlab install --user
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # fix and enhance
 - [x] CJK character display CORRECTLY now! 2022-3-9
-- [x] use `plotly_matlab` to `_send_display_data` into jupyter notebook like `plotly.py`, which are three layers for `outputs.data`, such as `"application/vnd.plotly.v1+json": {json_compatible_fig_dict}`, `"image/png":"base64"` and `"text/html":"plotly_fig_html"`. see: [dennischancs/plotly_matlab](https://github.com/dennischancs/plotly_matlab) ![](https://images.weserv.nl?url=https://raw.githubusercontent.com/dennischancs/pic/main/img/202203120246485.png)
+- [x] use `plotly_matlab` to `_send_display_data` into jupyter notebook like `plotly.py`, which are three layers for `outputs.data`, such as `"application/vnd.plotly.v1+json": {json_compatible_fig_dict}`, `"image/png":"base64"` and `"text/html":"plotly_fig_html"`. see: [dennischancs/plotly_matlab](https://github.com/dennischancs/imatlab/tree/dennischancs-patch-1) ![](https://images.weserv.nl?url=https://raw.githubusercontent.com/dennischancs/pic/main/img/202203120246485.png)
 
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -3,10 +3,13 @@
 - [x] use `plotly_matlab` to `_send_display_data` into jupyter notebook like `plotly.py`, which are three layers for `outputs.data`, such as `"application/vnd.plotly.v1+json": {json_compatible_fig_dict}`, `"image/png":"base64"` and `"text/html":"plotly_fig_html"`. see: [dennischancs/plotly_matlab](https://github.com/dennischancs/imatlab/tree/dennischancs-patch-1) ![](https://images.weserv.nl?url=https://raw.githubusercontent.com/dennischancs/pic/main/img/202203120246485.png)
 
 
+## Install
 ```bash
-pip install git+https://github.com/dennischancs/imatlab/tree/dennischancs-patch-1  # from Github
+pip install git+https://github.com/dennischancs/imatlab@dennischancs-patch-1  # from Github
 python -mimatlab install --user
 ```
+
+enable `fig2plotly` option  see: [dennischancs/plotly_matlab](https://github.com/dennischancs/plotly_matlab)
 
 ## Usage 
 
@@ -33,3 +36,6 @@ filename = ['测试fig2plotly'];
 %2: use `plotlyoffline.m`
 %fig2plotly(gcf, 'filename', filename, 'offline', true, 'open', true);
 ```
+
+
+## [More](./README.rst)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# fix and enhance
+- [x] CJK character display CORRECTLY now! 2022-3-9
+- [x] use `plotly_matlab` to `_send_display_data` into jupyter notebook like `plotly.py`, which are three layers for `outputs.data`, such as `"application/vnd.plotly.v1+json": {json_compatible_fig_dict}`, `"image/png":"base64"` and `"text/html":"plotly_fig_html"`. see: [dennischancs/plotly_matlab](https://github.com/dennischancs/plotly_matlab) ![](https://images.weserv.nl?url=https://raw.githubusercontent.com/dennischancs/pic/main/img/202203120246485.png)
+
+
+```bash
+pip install git+https://github.com/dennischancs/imatlab  # from Github
+python -mimatlab install --user
+```
+
+## Usage 
+
+```matlab
+%% one mothed to insert a matlab static figure as a cell to ipynb file
+%imatlab_export_fig('print-svg')  % `imatlab_export_fig()` should put it first to prevent matlab_figure windows popup
+
+%% one mothed to insert a plotly figure as a cell to ipynb file
+imatlab_export_fig('fig2plotly')
+
+
+plot(1:10,2:11);
+title('测试fig2plotly');
+filename = ['测试fig2plotly'];
+
+
+%% one mothed to convert plotly figure to static image with png/jpg/webp/svg/pdf formats
+% use `write_image.m` (recommend)
+%write_image(gcf,'imageFormat','png','saveFile',false)
+
+%% two mothed to export plotly figure with .html format
+%1: use `write_html.m` (recommend)
+%write_html(gcf)
+%2: use `plotlyoffline.m`
+%fig2plotly(gcf, 'filename', filename, 'offline', true, 'open', true);
+```

--- a/lib/imatlab/_kernel.py
+++ b/lib/imatlab/_kernel.py
@@ -14,7 +14,6 @@ from unittest.mock import patch
 import uuid
 import weakref
 from xml.etree import ElementTree as ET
-import re
 
 try:
     import importlib.metadata as _importlib_metadata

--- a/lib/imatlab/data/imatlab_export_fig.m
+++ b/lib/imatlab/data/imatlab_export_fig.m
@@ -52,8 +52,7 @@ function exported = imatlab_export_fig(exporter)
             if strcmp(set_exporter, 'fig2plotly')
                 exported{i} = [name, '.html'];
                 try
-                    fig2plotly(child, 'filename', name, ...
-                               'offline', true, 'open', false);
+                    plotlyoffline2(child, 'filename', name);
                 catch me
                     warning('fig2plotly failed to export a figure');
                     rethrow(me);


### PR DESCRIPTION
use `io.StringIO` in linux instead of `contextlib.ExitStack`